### PR TITLE
Correct invalid bundle IDs for targets

### DIFF
--- a/CocoaTypograf.xcodeproj/project.pbxproj
+++ b/CocoaTypograf.xcodeproj/project.pbxproj
@@ -690,7 +690,6 @@
 					"@loader_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
-				PRODUCT_BUNDLE_IDENTIFIER = io.github.dreadct.CocoaTypograf;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
@@ -714,7 +713,6 @@
 					"@loader_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
-				PRODUCT_BUNDLE_IDENTIFIER = io.github.dreadct.CocoaTypograf;
 				SKIP_INSTALL = YES;
 			};
 			name = Release;
@@ -735,7 +733,6 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "io.github.dreadct.CocoaTypograf-iOS";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -759,7 +756,6 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "io.github.dreadct.CocoaTypograf-iOS";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
Corrected following issues with bundle IDs:
1. CocoaTypograf-iOS target has bundle ID "io.github.dreadct.CocoaTypograf-iOS".
2. CocoaTypograf-macOS target has bundle ID "io.github.dreadct.CocoaTypograf" which is not a project default bundle ID ("io.github.dreadct.$(PRODUCT_NAME:rfc1034identifier)").

Resolves #10.